### PR TITLE
chore: try to create message earlier, increase retries

### DIFF
--- a/.github/workflows/daily-standup.yml
+++ b/.github/workflows/daily-standup.yml
@@ -4,13 +4,13 @@ on:
   schedule:
     # 10 AM Pacific Time
     # TODO: handle DST better
-    - cron: "0 18 * * 1-5" # 18:00 UTC = 10:00 PT during standard time
+    - cron: "0 17 * * 1-5" # 17:00 UTC = 9:00 PT during standard time
   workflow_dispatch:
 
 jobs:
   standup:
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 3
     permissions:
       contents: read
 
@@ -33,8 +33,8 @@ jobs:
         uses: nick-fields/retry@v3
         with:
           timeout_minutes: 10
-          max_attempts: 3
-          retry_wait_seconds: 1800 # 30 minutes
+          max_attempts: 8 # keep running until I create a new log for today
+          retry_wait_seconds: 900 # 15 minutes
           command: npm run start
         env:
           NOTION_TOKEN: ${{ secrets.NOTION_TOKEN }}


### PR DESCRIPTION
The idea here is that I'll create my daily log sometime between 9 and 10 am, and I'm happy for the update to get posted earlier. The real caveat here is I'll need to be careful making it right at 9:15, 9:30, or 9:45